### PR TITLE
Fix intellisense and static analysis not working with Webpack

### DIFF
--- a/build/webpack.config.ts
+++ b/build/webpack.config.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import * as Webpack from "webpack";
 import { CheckerPlugin } from "awesome-typescript-loader";
 
-export = {
+const config: Webpack.Configuration = {
   entry: "./index.ts",
   target: "node",
   output: {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/jest": "^19.2.4",
     "@types/node": "^7.0.27",
+    "@types/webpack": "^3.0.0",
     "awesome-typescript-loader": "^3.1.3",
     "jest": "^20.0.4",
     "ts-jest": "^20.0.5",


### PR DESCRIPTION
It needs the `@types/webpack` for it to work aswell as the explicit type definition.
You might want to squash this commit.

Sorry about that.